### PR TITLE
Fix parse error when syntax highlighting fails

### DIFF
--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -44,6 +44,12 @@ function getPackageJSON() {
 }
 
 const custom_css = `
+  .language-typescript { color: #0550ae; }
+  .language-typescript .string { color: #0a3069; }
+  .language-typescript .number { color: #005cc5; }
+  .language-typescript .class-name { color: #24292f; }
+  .token.keyword { color: #d73a49; }
+
   .token.language-javascript { color: #24292e; }
   .token.language-javascript .function { color: #005cc5; }
   .token.language-javascript .string { color: #032f62; }

--- a/src/preprocessReadme.ts
+++ b/src/preprocessReadme.ts
@@ -14,7 +14,8 @@ import { URL } from "url";
 const aliases: Record<string, string> = {
   sh: "bash",
   js: "javascript",
-  ts: "typescript"
+  ts: "typescript",
+  tsx: "typescript"
 };
 
 let md: Markdown;

--- a/src/preprocessReadme.ts
+++ b/src/preprocessReadme.ts
@@ -5,6 +5,7 @@ import prettier from "prettier";
 import Prism from "prismjs";
 import "prismjs/components/prism-bash";
 import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-jsx";
 import "prism-svelte";
 import isRelativeUrl from "is-relative-url";
 import { PreprocessorGroup } from "svelte/types/compiler/preprocess";

--- a/src/preprocessReadme.ts
+++ b/src/preprocessReadme.ts
@@ -4,6 +4,7 @@ import markdownItAnchor from "markdown-it-anchor";
 import prettier from "prettier";
 import Prism from "prismjs";
 import "prismjs/components/prism-bash";
+import "prismjs/components/prism-typescript";
 import "prism-svelte";
 import isRelativeUrl from "is-relative-url";
 import { PreprocessorGroup } from "svelte/types/compiler/preprocess";
@@ -13,6 +14,7 @@ import { URL } from "url";
 const aliases: Record<string, string> = {
   sh: "bash",
   js: "javascript",
+  ts: "typescript"
 };
 
 let md: Markdown;
@@ -55,7 +57,7 @@ export function preprocessReadme(opts: Partial<PreprocessReadmeOptions>): Pick<P
           )}\`}</pre>`;
         } catch (e) {
           console.error(`Could not highlight language "${lang}".`);
-          return "";
+          return `<pre class="language-${lang}">{@html \`${source}\`}</pre>`;
         }
       },
     });

--- a/test/README.md
+++ b/test/README.md
@@ -69,6 +69,12 @@ npm i -D svelte-readme
 localStorage.getItem("custom-theme-key");
 ```
 
+```ts
+interface Interface {
+  key: "value";
+}
+```
+
 ## [rollup.config.js](rollup.config.js)
 
 [package.json](package.json)


### PR DESCRIPTION
**Features**

- support typescript/jsx Prism.js syntax highlighting

**Fixes**

- render code source as HTML if highlighting fails